### PR TITLE
chore: update minimum Node version required to 12.13.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.13.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Set git identity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
         run: |-
           git config user.name "Automation"
           git config user.email "github-actions@github.com"
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.13.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Bump to next version

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.13.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -6,7 +6,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^10.17.0",
+      "version": "^12.13.0",
       "type": "build"
     },
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -16,6 +16,7 @@ const project = new JsiiProject({
   bin: {
     'cdk8s-server': 'lib/cli/cdk8s-server.js',
   },
+  minNodeVersion: '12.13.0',
 
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",
-    "@types/node": "^10.17.0",
+    "@types/node": "^12.13.0",
     "@typescript-eslint/eslint-plugin": "^4.27.0",
     "@typescript-eslint/parser": "^4.27.0",
     "cdk8s": "1.0.0-beta.3",
@@ -66,6 +66,9 @@
   "bundledDependencies": [
     "yaml"
   ],
+  "engines": {
+    "node": ">= 12.13.0"
+  },
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "version": "0.0.0",

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,7 +44,7 @@ export class Server {
           throw new Error(`cannot determine port from server address ${addr}`);
         }
 
-        return ok(addr.port);
+        return ok(addr?.port);
       });
 
       this.server.on('error', err => ko(err));

--- a/yarn.lock
+++ b/yarn.lock
@@ -745,10 +745,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.2.tgz#1f2b42c4be7156ff4a6f914b2fb03d05fa84e38d"
   integrity sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==
 
-"@types/node@^10.17.0":
-  version "10.17.60"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
-  integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
+"@types/node@^12.13.0":
+  version "12.20.26"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.26.tgz#a6db0d0577e40844f0b28c2a9289c09e5b44b541"
+  integrity sha512-gIt+h4u2uTho2bsH1K250fUv5fHU71ET1yWT7bM4523zV/XrFb9jlWBOV4DO8FpscY+Sz/WEr1EEjIP2H4yumQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
This is needed because `cdk8s` now requires that minimal version as well
(https://github.com/cdk8s-team/cdk8s-core/pull/51).
